### PR TITLE
Sometimes the Uri where we need to send the PATCH request is differen…

### DIFF
--- a/src/SmugMugModel.v2/Types/Images/Image/Image.manual.cs
+++ b/src/SmugMugModel.v2/Types/Images/Image/Image.manual.cs
@@ -11,6 +11,14 @@ namespace SmugMug.v2.Types
 {
     public partial class ImageEntity : SmugMugEntity
     {
+        public override string PatchUri
+        {
+            get
+            {
+                return "/api/v2/image/" + ImageKey;
+            }
+        }
+
         public async Task<AlbumImageShareUrisEntity> GetShareUrisAsync()
         {
             // /album/(*)/image/(*)!shareuris 

--- a/src/SmugMugModel.v2/Types/SmugMugEntity.cs
+++ b/src/SmugMugModel.v2/Types/SmugMugEntity.cs
@@ -50,6 +50,8 @@ namespace SmugMug.v2.Types
 
         public virtual string EntityId { get { return string.Empty; } }
 
+        public virtual string PatchUri { get { return Uri; } }
+
         public SmugMugEntity()
         {
 
@@ -64,7 +66,7 @@ namespace SmugMug.v2.Types
             // We get the modified properties and post them to the objects's uri
             var patchPropertiesWithValues = GetModifedPropertiesValue(GetPatchPropertiesName());
 
-            await PatchRequestAsync(Constants.Addresses.SmugMug + this.Uri, JsonHelpers.GetPayloadAsJson(patchPropertiesWithValues));
+            await PatchRequestAsync(Constants.Addresses.SmugMug + this.PatchUri, JsonHelpers.GetPayloadAsJson(patchPropertiesWithValues));
         }
 
         protected async Task CreateAsync(string uri, List<string> properties)


### PR DESCRIPTION
…t than the Uri of the object.

One example is with Images that are retrieved from Albums. In that case, the Uri of the image points to the image in the album and not to the actual image object.

Fixes #18 